### PR TITLE
Add generic type support

### DIFF
--- a/src/modules/SemanticTokenizer.ts
+++ b/src/modules/SemanticTokenizer.ts
@@ -101,8 +101,8 @@ export class DocumentSemanticTokenProvidor implements vscode.DocumentSemanticTok
                 let moduleNameSpaces = names.moduleNameSpaces;
                 let typeList = names.typeList;
 
-                const varDecl = /(?:any|let|int|adr|byte|char|float|bool|short|long|generic)\s*(?:\[\d+\])*\s*(?:<.*>)?\s*([\w\d_]+)\s*=.*/g;
-                const varDeclNoValue = /(?:any|let|int|adr|byte|char|float|bool|short|long|generic)\s*(?:\[\d+\])*\s*(?:<.*>)?\s+([\w\d_]+)\s*(?:[;\]\),=])/g;
+                const varDecl = /(?:any|let|int|adr|byte|char|float|bool|short|long|generic)(?:\s*::\s*<[^>]+>)?\s*(?:\[\d+\])*\s*(?:<.*>)?\s*([\w\d_]+)\s*=.*/g;
+                const varDeclNoValue = /(?:any|let|int|adr|byte|char|float|bool|short|long|generic)(?:\s*::\s*<[^>]+>)?\s*(?:\[\d+\])*\s*(?:<.*>)?\s+([\w\d_]+)\s*(?:[;\]\),=])/g;
                 const scopeStack: Set<string>[] = [new Set()];
 
 


### PR DESCRIPTION
## Summary
- support generic syntax in Parser variable regexes
- parse custom `Types()` declarations
- allow mixed type/function imports
- tokenize generic variable declarations

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d6052e1948328898d15a4de4b1c5b