### PR TITLE
Add types keyword and generic support

### DIFF
--- a/src/modules/ErrorChecker.ts
+++ b/src/modules/ErrorChecker.ts
@@ -6,7 +6,7 @@ const Keywords = [ 'int', 'adr', 'bool', 'byte', 'char', 'float', 'short', 'long
     , 'if', 'else', 'while', 'for', 'foreach', 'signs', 'return', 'new', 'as', 'needs', 'root',
     'my', 'class', 'struct', 'public', 'private', 'NULL', 'true', 'false', 'contract',
     'import', 'from', 'under', 'export', 'delete', 'const', 'mutable', 'enum', 'let', 'safe', 'dynamic',
-    'break', 'continue', 'void', 'any', 'padantic', 'fn', 'Apply', 'transform', 'immutable'];
+    'break', 'continue', 'void', 'any', 'padantic', 'fn', 'Apply', 'transform', 'immutable', 'types'];
 const deprecated = ['struct']
 
 export const GetErrors = (doc : vscode.TextDocument, errorList : vscode.DiagnosticCollection, nameSets : NameSets): void => {

--- a/src/modules/Parsing/Parser.ts
+++ b/src/modules/Parsing/Parser.ts
@@ -233,8 +233,17 @@ const getSets = async (text : string, NameSetsMemo : Set<string>, moduleName : s
 		}
 	}
 
-	for (let i = 0; i < lines.length; i++) {
-		const line = lines[i];
+        for (let i = 0; i < lines.length; i++) {
+                const line = lines[i];
+
+                // capture generic type declarations via types()
+                const typesMatch = line.match(/types\s*\(([^)]+)\)/);
+                if (typesMatch) {
+                        const tnames = typesMatch[1].split(',').map(t => t.trim()).filter(t => t);
+                        for (const t of tnames) {
+                                typeNames.add(t);
+                        }
+                }
 
 		// search the line a variable declaration
 		const variableDeclaration = /(?:any|let|int|adr|byte|char|float|bool|short|long|generic|byte)\s*(?:\[\d+\])*\s*(?:<.*>)?\s*([\w\d_]+)\s*=\s*(.*)/;
@@ -488,8 +497,8 @@ const getSets = async (text : string, NameSetsMemo : Set<string>, moduleName : s
 
 
 		// search the line for variable declarations with a type
-		for (const typeName of typeNames) {
-			const variableDeclaration = new RegExp(`(?:${typeName})\\s+([\\w\\d_]+)\\s*(?:[;\\]\\)\\,=])`);
+                for (const typeName of typeNames) {
+                        const variableDeclaration = new RegExp(`(?:${typeName})(?:\\s*::\\s*<[^>]+>)?\\s+([\\w\\d_]+)\\s*(?:[;\\]\\)\\,=])`);
 			let testLine = line;
 			let shift = 0;
 			let match = testLine.match(variableDeclaration);
@@ -508,7 +517,7 @@ const getSets = async (text : string, NameSetsMemo : Set<string>, moduleName : s
 
 		// search the line for function declarations with a type
 		for (const typeName of typeNames) {
-			const functionDeclaration = line.match(new RegExp(`(?:${typeName})\\s+([\\w\\d_]+)\\s*\\(([\\w\\d_\\s,<>?&\*]*)`));
+                        const functionDeclaration = line.match(new RegExp(`(?:${typeName})(?:\s*::\s*<[^>]+>)?\s+([\w\d_]+)\s*\(([\w\d_\s,<>?&\*]*)`));
 			if (functionDeclaration) {
 				const functionName = functionDeclaration[1];
 				const functionArguments = functionDeclaration[2].split(',');

--- a/syntaxes/aflat.tmLanguage.json
+++ b/syntaxes/aflat.tmLanguage.json
@@ -31,7 +31,7 @@
 		"keywords": {
 			"patterns": [{
 				"name": "keyword.control.aflat",
-				"match": "\\b(if|while|for|foreach|class|fn|enum|struct|else|return|new|delete|as|signs|contract|import|from|export|under|break|continue|Apply)\\b"
+                                "match": "\\b(if|while|for|foreach|class|fn|enum|struct|else|return|new|delete|as|signs|contract|import|from|export|under|break|continue|Apply|types)\\b"
 			},
 			{
 				"name":"storage.modifier.aflat",


### PR DESCRIPTION
## Summary
- recognize `types()` generic declarations when parsing
- allow `TypeName::<T>` generics for variables and functions
- add `types` keyword to error checker
- highlight `types` as a keyword

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e172c6be483288b66bf94ef3b59ce