### PR TITLE
Add union and match syntax support

### DIFF
--- a/src/modules/ErrorChecker.ts
+++ b/src/modules/ErrorChecker.ts
@@ -6,7 +6,8 @@ const Keywords = [ 'int', 'adr', 'bool', 'byte', 'char', 'float', 'short', 'long
     , 'if', 'else', 'while', 'for', 'foreach', 'signs', 'return', 'new', 'as', 'needs', 'root',
     'my', 'class', 'struct', 'public', 'private', 'NULL', 'true', 'false', 'contract',
     'import', 'from', 'under', 'export', 'delete', 'const', 'mutable', 'enum', 'let', 'safe', 'dynamic',
-    'break', 'continue', 'void', 'any', 'padantic', 'fn', 'Apply', 'transform', 'immutable'];
+    'break', 'continue', 'void', 'any', 'padantic', 'fn', 'Apply', 'transform', 'immutable', 'match',
+    'union', 'types'];
 const deprecated = ['struct']
 
 export const GetErrors = (doc : vscode.TextDocument, errorList : vscode.DiagnosticCollection, nameSets : NameSets): void => {

--- a/src/modules/Parsing/Parser.ts
+++ b/src/modules/Parsing/Parser.ts
@@ -237,19 +237,30 @@ const getSets = async (text : string, NameSetsMemo : Set<string>, moduleName : s
 		const line = lines[i];
 
 		// search the line a variable declaration
-		const variableDeclaration = /(?:any|let|int|adr|byte|char|float|bool|short|long|generic|byte)\s*(?:\[\d+\])*\s*(?:<.*>)?\s*([\w\d_]+)\s*=\s*(.*)/;
+                const variableDeclaration = /(?:any|let|int|adr|byte|char|float|bool|short|long|generic|byte)\s*(?:\[\d+\])*\s*(?:<.*>)?\s*([\w\d_]+)\s*=\s*(.*)/;
         let testLine = line;
         let shift = 0;
         let match = testLine.match(variableDeclaration);
         while (match) {
             if (match){
                 const identifier = match[1];
-				variableNames.add(identifier);
+                                variableNames.add(identifier);
                 testLine = testLine.substring(testLine.indexOf(identifier) + identifier.length);
                 shift = testLine.indexOf(identifier) + shift + identifier.length;
                 match = testLine.match(variableDeclaration);
             }
         }
+
+                // match template type declarations like types(T, J...)
+                const templateTypeMatch = line.match(/types\s*\(([^\)]*)\)/);
+                if (templateTypeMatch) {
+                        const inner = templateTypeMatch[1];
+                        const params = inner.split(',');
+                        for (const param of params) {
+                                const clean = param.trim().replace(/\.\.\.$/, '');
+                                if (clean) typeNames.add(clean);
+                        }
+                }
 
 		// match a declaration that looks 
 

--- a/src/modules/Parsing/Parser.ts
+++ b/src/modules/Parsing/Parser.ts
@@ -316,34 +316,61 @@ const getSets = async (text : string, NameSetsMemo : Set<string>, moduleName : s
 			typeNames.add(className);
 		}
 
-		// search the line for an enum declaration
-		const enumDeclaration = line.match(/(?:enum)\s+([\w\d_]+)\s*/);
-		if (enumDeclaration) {
-			const enumName = enumDeclaration[1];
-			//add the enum name to the list of known types
-			typeNames.add(enumName);
+                // search the line for an enum declaration
+                const enumDeclaration = line.match(/(?:enum)\s+([\w\d_]+)\s*/);
+                if (enumDeclaration) {
+                        const enumName = enumDeclaration[1];
+                        //add the enum name to the list of known types
+                        typeNames.add(enumName);
 
-			// loop through the lines until the end of the enum
-			let enumBody = '';
-			for (let j = i + 1; j < lines.length; j++) {
-				const enumLine = lines[j];
-				enumBody += enumLine;
-				if (enumLine.includes('};')) {
-					// remove closing brace and semicolon
-					enumBody = enumBody.replace('};', '');
-					break;
-				}
-			}
-			// remove newlines
-			enumBody = enumBody.replace(/\r?\n|\r/g, '');
-			//split by commas
-			const enumValues = enumBody.split(',');
-			// add each enum value to the list of known variables
-			for (let j = 0; j < enumValues.length; j++) {
-				const enumValue = enumValues[j].trim();
-				variableNames.add(enumValue);
-			};
-		};
+                        // loop through the lines until the end of the enum
+                        let enumBody = '';
+                        for (let j = i + 1; j < lines.length; j++) {
+                                const enumLine = lines[j];
+                                enumBody += enumLine;
+                                if (enumLine.includes('};')) {
+                                        // remove closing brace and semicolon
+                                        enumBody = enumBody.replace('};', '');
+                                        break;
+                                }
+                        }
+                        // remove newlines
+                        enumBody = enumBody.replace(/\r?\n|\r/g, '');
+                        //split by commas
+                        const enumValues = enumBody.split(',');
+                        // add each enum value to the list of known variables
+                        for (let j = 0; j < enumValues.length; j++) {
+                                const enumValue = enumValues[j].trim();
+                                variableNames.add(enumValue);
+                        };
+                };
+
+                // search the line for a union declaration
+                const unionDeclaration = line.match(/(?:union)\s+([\w\d_]+)\s*/);
+                if (unionDeclaration) {
+                        const unionName = unionDeclaration[1];
+                        typeNames.add(unionName);
+
+                        // gather union body similar to enum to capture variant names
+                        let unionBody = '';
+                        for (let j = i + 1; j < lines.length; j++) {
+                                const unionLine = lines[j];
+                                unionBody += unionLine;
+                                if (unionLine.includes('};')) {
+                                        unionBody = unionBody.replace('};', '');
+                                        break;
+                                }
+                        }
+                        unionBody = unionBody.replace(/\r?\n|\r/g, '');
+                        const unionValues = unionBody.split(',');
+                        for (let j = 0; j < unionValues.length; j++) {
+                                let val = unionValues[j].trim();
+                                if (val === '') continue;
+                                // remove generic or parameter list
+                                val = val.split(/[(<]/)[0].trim();
+                                variableNames.add(val);
+                        }
+                }
 
 		// search the line a function declaration ie int foo(int a, int b)
 		const functionDeclaration = line.match(/(?:any|void|int|adr|char|float|bool|short|byte|long|generic)\s+([\w\d_]+)\s*\(([\w\d_\s<>,?&\*]*)\)/);

--- a/syntaxes/aflat.tmLanguage.json
+++ b/syntaxes/aflat.tmLanguage.json
@@ -31,7 +31,7 @@
 		"keywords": {
 			"patterns": [{
 				"name": "keyword.control.aflat",
-				"match": "\\b(if|while|for|foreach|class|fn|enum|struct|else|return|new|delete|as|signs|contract|import|from|export|under|break|continue|Apply)\\b"
+                                "match": "\\b(if|while|for|foreach|class|fn|enum|struct|union|match|types|else|return|new|delete|as|signs|contract|import|from|export|under|break|continue|Apply)\\b"
 			},
 			{
 				"name":"storage.modifier.aflat",


### PR DESCRIPTION
## Summary
- support `union`, `match`, and `types` keywords for syntax highlighting
- parse union declarations to add new types and variant names

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687777fecbc88328907311f494c034b1