### PR TITLE
Add foreach variable support

### DIFF
--- a/src/modules/CompletionProvider.ts
+++ b/src/modules/CompletionProvider.ts
@@ -14,6 +14,7 @@ function variablesInScope(lines: string[], lineNumber: number): Set<string> {
     const scopeStack: Set<string>[] = [new Set()];
     const varDecl = /(?:any|let|int|adr|byte|char|float|bool|short|long|generic)\s*(?:\[\d+\])*\s*(?:<.*>)?\s*([\w\d_]+)\s*=.*/g;
     const varDeclNoValue = /(?:any|let|int|adr|byte|char|float|bool|short|long|generic)\s*(?:\[\d+\])*\s*(?:<.*>)?\s+([\w\d_]+)\s*(?:[;\]\),=])/g;
+    const foreachDecl = /foreach\s+([\w\d_]+)\s+in/g;
 
     for (let i = 0; i <= lineNumber; i++) {
         const line = cleanLine(lines[i]);
@@ -26,6 +27,10 @@ function variablesInScope(lines: string[], lineNumber: number): Set<string> {
             scopeStack[scopeStack.length - 1].add(match[1]);
         }
         varDeclNoValue.lastIndex = 0;
+        while ((match = foreachDecl.exec(line)) !== null) {
+            scopeStack[scopeStack.length - 1].add(match[1]);
+        }
+        foreachDecl.lastIndex = 0;
         for (const ch of line) {
             if (ch === '{') {
                 scopeStack.push(new Set());

--- a/src/modules/Parsing/Parser.ts
+++ b/src/modules/Parsing/Parser.ts
@@ -390,7 +390,7 @@ const getSets = async (text : string, NameSetsMemo : Set<string>, moduleName : s
                 }
 
 		// search the line a function declaration ie int foo(int a, int b)
-		const functionDeclaration = line.match(/(?:any|void|int|adr|char|float|bool|short|byte|long|generic)\s+([\w\d_]+)\s*\(([\w\d_\s<>,?&\*]*)\)/);
+                const functionDeclaration = line.match(/(?:any|void|int|adr|char|float|bool|short|byte|long|generic)\s+([\w\d_]+)\s*\(([\w\d_\s<>,?&:\*]*)\)/);
 		if (functionDeclaration) {
 			const functionName = functionDeclaration[1];
 
@@ -467,7 +467,7 @@ const getSets = async (text : string, NameSetsMemo : Set<string>, moduleName : s
 		}
 
 		// Match `fn functionName(type1 param1, type2 param2) -> returnType {`
-		const functionRegex = /fn\s+([\w\d_]+)\s*\(([\w\d_\s<>,?&\*]*)\)\s*(?:->\s*([\w\d_?]+))?/;
+                const functionRegex = /fn\s+([\w\d_]+)\s*\(([\w\d_\s<>,?&:\*]*)\)\s*(?:->\s*([\w\d_?]+))?/;
 		for (let i = 0; i < lines.length; i++) {
 			const line = lines[i];
 
@@ -552,7 +552,7 @@ const getSets = async (text : string, NameSetsMemo : Set<string>, moduleName : s
 
 		// search the line for function declarations with a type
 		for (const typeName of typeNames) {
-			const functionDeclaration = line.match(new RegExp(`(?:${typeName})\\s+([\\w\\d_]+)\\s*\\(([\\w\\d_\\s,<>?&\*]*)`));
+                        const functionDeclaration = line.match(new RegExp(`(?:${typeName})\s+([\w\d_]+)\s*\(([\w\d_\s,<>?&:\*]*)`));
 			if (functionDeclaration) {
 				const functionName = functionDeclaration[1];
 				const functionArguments = functionDeclaration[2].split(',');
@@ -600,7 +600,7 @@ const getSets = async (text : string, NameSetsMemo : Set<string>, moduleName : s
 		// search the line for function declarations with a type and overload operator
 		for (const typeName of typeNames) {
 
-			const fdec = line.match(new RegExp(`(?:${typeName})\\s+([\\w\\d_]+)\\s*(?:<<.+>>)\\s*\\(([\\w\\d_\\s,<>?&\*]*)`));
+                        const fdec = line.match(new RegExp(`(?:${typeName})\s+([\w\d_]+)\s*(?:<<.+>>)\s*\(([\w\d_\s,<>?&:\*]*)`));
 			if (fdec) {
 				const functionName = fdec[1];
 				functionNames.add(functionName);

--- a/src/modules/Parsing/Parser.ts
+++ b/src/modules/Parsing/Parser.ts
@@ -552,7 +552,7 @@ const getSets = async (text : string, NameSetsMemo : Set<string>, moduleName : s
 
 		// search the line for function declarations with a type
 		for (const typeName of typeNames) {
-                        const functionDeclaration = line.match(new RegExp(`(?:${typeName})\s+([\w\d_]+)\s*\(([\w\d_\s,<>?&:\*]*)`));
+                        const functionDeclaration = line.match(new RegExp(`(?:${typeName})\\s+([\\w\\d_]+)\\s*\\(([\w\d_\s,<>?&:\*]*)`));
 			if (functionDeclaration) {
 				const functionName = functionDeclaration[1];
 				const functionArguments = functionDeclaration[2].split(',');
@@ -600,7 +600,7 @@ const getSets = async (text : string, NameSetsMemo : Set<string>, moduleName : s
 		// search the line for function declarations with a type and overload operator
 		for (const typeName of typeNames) {
 
-                        const fdec = line.match(new RegExp(`(?:${typeName})\s+([\w\d_]+)\s*(?:<<.+>>)\s*\(([\w\d_\s,<>?&:\*]*)`));
+                        const fdec = line.match(new RegExp(`(?:${typeName})\\s+([\\w\\d_]+)\\s*(?:<<.+>>)\\s*\\(([\w\d_\s,<>?&:\*]*)`));
 			if (fdec) {
 				const functionName = fdec[1];
 				functionNames.add(functionName);

--- a/src/modules/Parsing/Parser.ts
+++ b/src/modules/Parsing/Parser.ts
@@ -265,18 +265,24 @@ const getSets = async (text : string, NameSetsMemo : Set<string>, moduleName : s
 		// match a declaration that looks 
 
 		// match a variable declaration without a value
-		const variableDeclarationWithoutValue = /(?:any|let|int|adr|byte|char|float|bool|short|long|generic)\s*(?:\[\d+\])*\s*(?:<.*>)?\s+([\w\d_]+)\s*(?:[;\]\)\,=])/;
+                const variableDeclarationWithoutValue = /(?:any|let|int|adr|byte|char|float|bool|short|long|generic)\s*(?:\[\d+\])*\s*(?:<.*>)?\s+([\w\d_]+)\s*(?:[;\]\)\,=])/;
         testLine = line;
         shift = 0;
         match = testLine.match(variableDeclarationWithoutValue);
         while (match) {
             if (match){
                 const identifier = match[1];
-				variableNames.add(identifier);
+                                variableNames.add(identifier);
                 testLine = testLine.substring(testLine.indexOf(identifier) + identifier.length);
                 shift = testLine.indexOf(identifier) + shift + identifier.length;
                 match = testLine.match(variableDeclarationWithoutValue);
             }
+        }
+
+                const foreachDeclaration = /foreach\s+([\w\d_]+)\s+in/;
+        const foreachMatch = line.match(foreachDeclaration);
+        if (foreachMatch) {
+            variableNames.add(foreachMatch[1]);
         }
 
 		// match 'under'

--- a/src/modules/SemanticTokenizer.ts
+++ b/src/modules/SemanticTokenizer.ts
@@ -103,6 +103,7 @@ export class DocumentSemanticTokenProvidor implements vscode.DocumentSemanticTok
 
                 const varDecl = /(?:any|let|int|adr|byte|char|float|bool|short|long|generic)\s*(?:\[\d+\])*\s*(?:<.*>)?\s*([\w\d_]+)\s*=.*/g;
                 const varDeclNoValue = /(?:any|let|int|adr|byte|char|float|bool|short|long|generic)\s*(?:\[\d+\])*\s*(?:<.*>)?\s+([\w\d_]+)\s*(?:[;\]\),=])/g;
+                const foreachDecl = /foreach\s+([\w\d_]+)\s+in/g;
                 const scopeStack: Set<string>[] = [new Set()];
 
 
@@ -428,6 +429,10 @@ export class DocumentSemanticTokenProvidor implements vscode.DocumentSemanticTok
                                 scopeStack[scopeStack.length - 1].add(match[1]);
                         }
                         varDeclNoValue.lastIndex = 0;
+                        while ((match = foreachDecl.exec(clean)) !== null) {
+                                scopeStack[scopeStack.length - 1].add(match[1]);
+                        }
+                        foreachDecl.lastIndex = 0;
                         const currentVars = new Set<string>(variableNames);
                         for (const set of scopeStack) set.forEach(v => currentVars.add(v));
 

--- a/syntaxes/aflat.tmLanguage.json
+++ b/syntaxes/aflat.tmLanguage.json
@@ -31,7 +31,7 @@
 		"keywords": {
 			"patterns": [{
 				"name": "keyword.control.aflat",
-                                "match": "\\b(if|while|for|foreach|class|fn|enum|struct|union|match|types|else|return|new|delete|as|signs|contract|import|from|export|under|break|continue|Apply)\\b"
+                                "match": "\\b(if|while|for|foreach|class|fn|enum|struct|union|match|types|else|return|new|delete|as|signs|contract|import|from|export|under|break|continue|Apply|Self)\\b"
 			},
 			{
 				"name":"storage.modifier.aflat",


### PR DESCRIPTION
## Summary
- support new `foreach var in list` syntax
- treat foreach iterator variables as valid variables for completions and semantic tokens

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68847e09b15883289309a27023757853