### PR TITLE
Handle vector generics

### DIFF
--- a/src/modules/Constents.ts
+++ b/src/modules/Constents.ts
@@ -11,6 +11,7 @@ export const RETURN_TYPES: string[] = [
     'short',
     'long',
     'generic',
+    'vector',
 ];
 
 export const TYPES: Type[] = RETURN_TYPES.map((type: string) => ({

--- a/src/modules/Parsing/Parser.ts
+++ b/src/modules/Parsing/Parser.ts
@@ -237,7 +237,7 @@ const getSets = async (text : string, NameSetsMemo : Set<string>, moduleName : s
 		const line = lines[i];
 
 		// search the line a variable declaration
-                const variableDeclaration = /(?:any|let|int|adr|byte|char|float|bool|short|long|generic|byte)\s*(?:\[\d+\])*\s*(?:<.*>)?\s*([\w\d_]+)\s*=\s*(.*)/;
+                const variableDeclaration = /(?:public|private|static|const|mutable|safe|dynamic|immutable|padantic)?\s*(?:any|let|int|adr|byte|char|float|bool|short|long|generic|vector)\s*(?:\[\d+\])*\s*(?:::<[^>]+>|<[^>]+>)?\s*([\w\d_]+)\s*=\s*(.*)/;
         let testLine = line;
         let shift = 0;
         let match = testLine.match(variableDeclaration);
@@ -265,7 +265,7 @@ const getSets = async (text : string, NameSetsMemo : Set<string>, moduleName : s
 		// match a declaration that looks 
 
 		// match a variable declaration without a value
-                const variableDeclarationWithoutValue = /(?:any|let|int|adr|byte|char|float|bool|short|long|generic)\s*(?:\[\d+\])*\s*(?:<.*>)?\s+([\w\d_]+)\s*(?:[;\]\)\,=])/;
+                const variableDeclarationWithoutValue = /(?:public|private|static|const|mutable|safe|dynamic|immutable|padantic)?\s*(?:any|let|int|adr|byte|char|float|bool|short|long|generic|vector)\s*(?:\[\d+\])*\s*(?:::<[^>]+>|<[^>]+>)?\s+([\w\d_]+)\s*(?:[;\]\)\,=])/;
         testLine = line;
         shift = 0;
         match = testLine.match(variableDeclarationWithoutValue);
@@ -532,8 +532,8 @@ const getSets = async (text : string, NameSetsMemo : Set<string>, moduleName : s
 
 
 		// search the line for variable declarations with a type
-		for (const typeName of typeNames) {
-			const variableDeclaration = new RegExp(`(?:${typeName})\\s+([\\w\\d_]+)\\s*(?:[;\\]\\)\\,=])`);
+                for (const typeName of typeNames) {
+                        const variableDeclaration = new RegExp(`(?:public|private|static|const|mutable|safe|dynamic|immutable|padantic)?\\s*(?:${typeName})(?:::<[^>]+>|<[^>]+>)?\\s+([\\w\\d_]+)\\s*(?:[;\\]\\)\\,=])`);
 			let testLine = line;
 			let shift = 0;
 			let match = testLine.match(variableDeclaration);

--- a/src/modules/SemanticTokenizer.ts
+++ b/src/modules/SemanticTokenizer.ts
@@ -101,8 +101,8 @@ export class DocumentSemanticTokenProvidor implements vscode.DocumentSemanticTok
                 let moduleNameSpaces = names.moduleNameSpaces;
                 let typeList = names.typeList;
 
-                const varDecl = /(?:any|let|int|adr|byte|char|float|bool|short|long|generic)\s*(?:\[\d+\])*\s*(?:<.*>)?\s*([\w\d_]+)\s*=.*/g;
-                const varDeclNoValue = /(?:any|let|int|adr|byte|char|float|bool|short|long|generic)\s*(?:\[\d+\])*\s*(?:<.*>)?\s+([\w\d_]+)\s*(?:[;\]\),=])/g;
+                const varDecl = /(?:public|private|static|const|mutable|safe|dynamic|immutable|padantic)?\s*(?:any|let|int|adr|byte|char|float|bool|short|long|generic|vector)\s*(?:\[\d+\])*\s*(?:::<[^>]+>|<[^>]+>)?\s*([\w\d_]+)\s*=.*/g;
+                const varDeclNoValue = /(?:public|private|static|const|mutable|safe|dynamic|immutable|padantic)?\s*(?:any|let|int|adr|byte|char|float|bool|short|long|generic|vector)\s*(?:\[\d+\])*\s*(?:::<[^>]+>|<[^>]+>)?\s+([\w\d_]+)\s*(?:[;\]\),=])/g;
                 const foreachDecl = /foreach\s+([\w\d_]+)\s+in/g;
                 const scopeStack: Set<string>[] = [new Set()];
 


### PR DESCRIPTION
## Summary
- add `vector` to built-in types
- support generic variable declarations (e.g. `vector::<T>`) with optional modifiers

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68849647ddb483289f174e2b66111bea