### PR TITLE
Ensure when clauses validated during statement generation

### DIFF
--- a/src/modules/Parsing/LanguageTools.test.ts
+++ b/src/modules/Parsing/LanguageTools.test.ts
@@ -91,6 +91,24 @@ describe('LanguageTools', () => {
             const exportsOnly = extractFunction(mockText, 'notFound', 'Test', true);
             expect(exportsOnly.error).toEqual('Function notFound not found');
         });
+
+        it('should handle when clauses in functions', () => {
+            const whenText = 'int foo(int a) when a > 0 { return a; };';
+            const res = extractFunction(whenText, 'foo', 'Test');
+            expect(res.data).toEqual({
+                ident: 'foo',
+                returnType: 'int',
+                moduleName: 'Test',
+                params: ['int a'],
+                doc: undefined,
+            });
+        });
+
+        it('should error on empty when clause', () => {
+            const invalidWhen = 'int foo() when { return 0; };';
+            const res = extractFunction(invalidWhen, 'foo', 'Test');
+            expect(res.error).toEqual('Empty when clause');
+        });
     });
 
     describe('extractClassText', () => {
@@ -131,6 +149,12 @@ describe('LanguageTools', () => {
             // should have 2 functions
             const data = res.data as Signature[];
             expect(data.length).toBe(2);
+        });
+
+        it('should error when a function has an empty when clause', () => {
+            const badText = 'export int foo() when { return 0; };';
+            const res = extractFunctions(badText, 'Test', true);
+            expect(res.error).toEqual('Empty when clause');
         });
     });
 

--- a/src/modules/Parsing/LanguageTools.ts
+++ b/src/modules/Parsing/LanguageTools.ts
@@ -23,6 +23,17 @@ const removeSingleQuotedStrings  = (line: string): string => {
     // Replace all double quoted strings with an empty string
     return line.replace(regex, '');
 }
+
+const checkWhenClause = (line: string): string | undefined => {
+    const whenMatch = line.match(/\)\s*when\s*([^\{]*)/);
+    if (whenMatch) {
+        const clause = whenMatch[1].trim();
+        if (clause === '') {
+            return 'Empty when clause';
+        }
+    }
+    return undefined;
+}
   
 
 /*
@@ -65,7 +76,12 @@ const extractFunction = (text: string, name: string, moduleName: string, exports
             args.forEach((arg, i) => {
                 args[i] = arg.trim();
             });
-            
+
+            const whenError = checkWhenClause(line);
+            if (whenError) {
+                return {error: whenError};
+            }
+
             // check the previous lines for docstrings
             let docstring = '';
             if (lines.indexOf(line) > 0) {
@@ -249,6 +265,11 @@ const extractFunctions = (text: string, moduleName: string, exportsOnly?: boolea
         args.forEach((arg, i) => {
             args[i] = arg.trim();
         });
+
+        const whenError = checkWhenClause(line);
+        if (whenError) {
+            return {error: whenError};
+        }
 
         // check the previous lines for docstrings
         let docstring = '';


### PR DESCRIPTION
## Summary
- validate `when` clauses when parsing functions
- error on empty `when` clauses during bulk function extraction
- test coverage for `when` clause handling

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae14b8e3088328acf04cdd5f260d4d